### PR TITLE
Basic auth

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -36,6 +36,7 @@ class NginxConfig
     json["clean_urls"] ||= DEFAULT[:clean_urls]
     json["https_only"] ||= DEFAULT[:https_only]
 
+    json["basic_auth"] = true unless ENV['BASIC_AUTH_USERNAME'].nil?
     json["basic_auth"] ||= DEFAULT[:basic_auth]
     json["basic_auth_htpasswd_path"] ||= DEFAULT[:basic_auth_htpasswd_path]
 

--- a/scripts/config/make-htpasswd
+++ b/scripts/config/make-htpasswd
@@ -13,4 +13,4 @@ PASSWORD    = ENV["BASIC_AUTH_PASSWORD"]
 
 htpasswd    = "#{USERNAME}:#{PASSWORD}" unless (USERNAME.nil? || PASSWORD.nil?)
 
-File.write(HTPASSWD, htpasswd) if (config["basic_auth"] && !htpasswd.nil?)
+File.write(HTPASSWD, htpasswd) if !htpasswd.nil?

--- a/scripts/config/make-htpasswd
+++ b/scripts/config/make-htpasswd
@@ -13,4 +13,4 @@ PASSWORD    = ENV["BASIC_AUTH_PASSWORD"]
 
 htpasswd    = "#{USERNAME}:#{PASSWORD}" unless (USERNAME.nil? || PASSWORD.nil?)
 
-File.write(HTPASSWD, htpasswd) if !htpasswd.nil?
+File.open(HTPASSWD, 'a') { |file| file.puts(htpasswd) } if !htpasswd.nil?

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -42,6 +42,11 @@ http {
     error_page 404 500 /<%= error_page %>;
   <% end %>
 
+  <% if basic_auth %>
+    auth_basic "Restricted";
+    auth_basic_user_file <%= basic_auth_htpasswd_path %>;
+  <% end %>
+
     location / {
       mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
       mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
@@ -73,10 +78,6 @@ http {
       try_files $uri $uri/ /$uri.html $path $fallback;
     <% else %>
       try_files $uri $path $fallback;
-    <% end %>
-    <% if basic_auth %>
-      auth_basic "Restricted";
-      auth_basic_user_file <%= basic_auth_htpasswd_path %>;
     <% end %>
     }
   <% end %>

--- a/spec/simple_spec.rb
+++ b/spec/simple_spec.rb
@@ -144,9 +144,9 @@ RSpec.describe "Simple" do
   end
 
   describe "basic_auth" do
-    let(:name) { "basic_auth" }
+    context "static.json without basic_auth key" do
+      let(:name) { "hello_world" }
 
-    context "basic_auth" do
       let(:env) {
         {
           "BASIC_AUTH_USERNAME" => "test",
@@ -155,10 +155,24 @@ RSpec.describe "Simple" do
       }
 
       it "should require authentication" do
-        app.run do
-          response = app.get("/foo.html")
-          expect(response.code).to eq("401")
-        end
+        response = app.get("/index.html")
+        expect(response.code).to eq("401")
+      end
+    end
+
+    context "static.json with static.json" do
+      let(:name) { "basic_auth" }
+
+      let(:env) {
+        {
+          "BASIC_AUTH_USERNAME" => "test",
+          "BASIC_AUTH_PASSWORD" => "$apr1$/pb2/xQR$cn7UPcTOLymIH1ZMe.NfO."
+        }
+      }
+
+      it "should require authentication" do
+        response = app.get("/foo.html")
+        expect(response.code).to eq("401")
       end
     end
   end

--- a/spec/simple_spec.rb
+++ b/spec/simple_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "Simple" do
       end
     end
 
-    context "static.json with static.json" do
+    context "static.json with basic_auth key and .htpasswd" do
       let(:name) { "basic_auth" }
 
       let(:env) {


### PR DESCRIPTION
Hi @randallagordon. Some features for your PR
1. Fixed tests. Moved `auth_basic` statements from `location` to `server` in nginx config 
2. If there is environment variable `BASIC_AUTH_USERNAME` then automaticaly enable basic_auth option. Added spec for that case.
